### PR TITLE
Do not send image if config says so

### DIFF
--- a/lib/module_base.py
+++ b/lib/module_base.py
@@ -118,7 +118,7 @@ class ModuleBase():
                 if data:
                     data, image = self.process_and_measure(data, image, channel_name)
                 if data and self.sender:
-                    self.sender.send(data, image)
+                    self.sender.send(data, image if self.config['send_image'] else None)
         elif self.sender:
             # We don't have receiver but sender
             data, image = self.process_and_measure(None, None, '')


### PR DESCRIPTION
- Currently, if the config specifies that a given module should not be sending the image, this only appears to be respected when the module has only a sender.
- This commit applies the same simple logic to the case when there is a sender and also receiver(s)