### PR TITLE
Fix bug where `self.receiver` (a dict) is being checked against a string in the image_preview module

### DIFF
--- a/modules/utils/image_preview.py
+++ b/modules/utils/image_preview.py
@@ -11,7 +11,7 @@ class ImagePreview(ModuleBase):
 
     def process(self, data, image, receiver_channel):
 
-        if 'tracker_data' == self.receiver:
+        if 'tracker_data' in self.receiver:
             if receiver_channel == 'image_data':
                 self.last_image.append([data, image])
             else:


### PR DESCRIPTION
- Because of the erroneous check, the OpenFace tracker data is currently not shown on the image preview even if the user intends it